### PR TITLE
fix SyncSquare luminosity

### DIFF
--- a/VisualStimulation/VStim/VStim.m
+++ b/VisualStimulation/VStim/VStim.m
@@ -221,8 +221,9 @@ classdef (Abstract) VStim < handle
             
             maskblobOn=maskblobOff; %make on mask addition
             if obj.displaySyncSignal
-                maskblobOn((obj.rect(1,4)-obj.syncSquareSizePix):end,1:obj.syncSquareSizePix,:)=obj.syncSquareLuminosity;
-                maskblobOff((obj.rect(1,4)-obj.syncSquareSizePix):end,1:obj.syncSquareSizePix,2)=obj.syncSquareLuminosity;
+                maskblobOn((obj.rect(1,4)-obj.syncSquareSizePix):end,1:obj.syncSquareSizePix,1)=obj.syncSquareLuminosity;
+                maskblobOn((obj.rect(1,4)-obj.syncSquareSizePix):end,1:obj.syncSquareSizePix,2)=obj.whiteIdx;
+                maskblobOff((obj.rect(1,4)-obj.syncSquareSizePix):end,1:obj.syncSquareSizePix,2)=obj.whiteIdx;
             end 
             
             % Build a single transparency mask texture:


### PR DESCRIPTION
previously, changing the value of SyncSquareLuminosity in VStim from the defualt 255 resulted in a change of both luminosity and transparency, due to how the ON condition was constructed.
It is now changed and any value of 0-255 can be displayed, while the transparency remains the required 255.
This is a patch-up solution, though. Probably should redefine the process of constructing the SyncSquare in the future, to allow for transparency modification, should one need to.

GuyH

Co-Authored-By: guyhyman <guyhyman@users.noreply.github.com>
Co-Authored-By: Mark Shein-Idelson