### PR TITLE
Fixing RectGrid

### DIFF
--- a/VisualStimulation/VStim/MarkStims/VS_rectGrid.m
+++ b/VisualStimulation/VStim/MarkStims/VS_rectGrid.m
@@ -166,7 +166,7 @@ classdef VS_rectGrid < VStim
                 WaitSecs(obj.interTrialDelay-(GetSecs-obj.off_Flip(i)));
             end
             obj.pos(end)=[]; %remove the last stim which is not shown
-            luminosities(end)=[];%remove the last stim which is not shown
+            obj.luminosities(end)=[];%remove the last stim which is not shown
             
             WaitSecs(obj.postSessionDelay);
             obj.sendTTL(1,false); %session end trigger


### PR DESCRIPTION
An undetected bug from Merge request #15 (Mark---Development): Mark added a line referring to obj.luminosities in the RectGrid stimulation, without the prefix "obj.". So matlab threw an error at the end of the stimulation and the parameter file was not saved properly.