### PR TITLE
workaround 2020 change

### DIFF
--- a/dataAnalysisObjects/recAnalysis.m
+++ b/dataAnalysisObjects/recAnalysis.m
@@ -272,11 +272,11 @@ classdef (Abstract) recAnalysis < handle
             
             
             %get data from excel spread sheet
-            Vers = version('-release');
-            if str2num(Vers(1:4)) >= 2020
-                obj.recTable = readtable(obj.excelRecordingDataFileName,'Format','auto');
-            else
+            
+            if verLessThan('matlab', '9.8')
                 obj.recTable = readtable(obj.excelRecordingDataFileName);
+            else
+                obj.recTable = readtable(obj.excelRecordingDataFileName,'Format','auto');
             end
             xlsFieldNames=obj.recTable.Properties.VariableNames;
             maxRow=size(obj.recTable,1);

--- a/dataAnalysisObjects/recAnalysis.m
+++ b/dataAnalysisObjects/recAnalysis.m
@@ -272,7 +272,12 @@ classdef (Abstract) recAnalysis < handle
             
             
             %get data from excel spread sheet
-            obj.recTable = readtable(obj.excelRecordingDataFileName);
+            Vers = version('-release');
+            if str2num(Vers(1:4)) >= 2020
+                obj.recTable = readtable(obj.excelRecordingDataFileName,'Format','auto');
+            else
+                obj.recTable = readtable(obj.excelRecordingDataFileName);
+            end
             xlsFieldNames=obj.recTable.Properties.VariableNames;
             maxRow=size(obj.recTable,1);
                 


### PR DESCRIPTION
As of 2020a, the "readtable" function has some behavioral changes.
In my case, it started reading the xlsx file 40 rows after the header. Don't know why exactly why.
According to the docs, setting the 'format' property to auto reverts the behavior of readtable back. This workaround wroked for me. Since I can't be sure this works for earlier versions, I conditioned the workaround to 2020 and after.