### PR TITLE
Fixs for reading OE recs

### DIFF
--- a/dataAnalysisObjects/@MEAAnalysis/MEAAnalysis.m
+++ b/dataAnalysisObjects/@MEAAnalysis/MEAAnalysis.m
@@ -744,6 +744,7 @@ classdef MEAAnalysis < recAnalysis
             addParameter(parseObj,'overwrite',false,@isnumeric);
             addParameter(parseObj,'inputParams',false,@isnumeric);
             addParameter(parseObj,'trialStartEndDigiTriggerNumbers',[3 4],@isnumeric);
+            addParameter(parseObj,'analogChNum',[],@isnumeric);
             addParameter(parseObj,'noisyAnalog',false,@isnumeric);
             parseObj.parse(varargin{:});
             if parseObj.Results.inputParams
@@ -772,7 +773,9 @@ classdef MEAAnalysis < recAnalysis
             T=load(obj.files.getDigitalTriggers);
             
             disp('Syncing diode signal...');
-            [frameShifts,upCross,downCross,digiTriggers,transitionNotFound]=frameTimeFromDiode(obj.currentDataObj,'trialStartEndDigiTriggerNumbers',trialStartEndDigiTriggerNumbers,'T',T.tTrig,'noisyAnalog',noisyAnalog);
+            [frameShifts,upCross,downCross,digiTriggers,transitionNotFound]=frameTimeFromDiode(obj.currentDataObj,...
+                'trialStartEndDigiTriggerNumbers',trialStartEndDigiTriggerNumbers,...
+                'T',T.tTrig,'noisyAnalog',noisyAnalog,'analogChNum',analogChNum);
             save(saveFileName,'par','frameShifts','upCross','downCross','digiTriggers','transitionNotFound','-v7.3');
             
         end


### PR DESCRIPTION
Branch was created to deal with mislabeling of analog channels in the metadata.
I updated the code to identify the channel type by the XML setting file (which maintains its format between recording types), in the case where the channel filenames are pre-labeled as CH/AD/AU by the OE software.
In addition, getDiodeSync method now has a new optional parameter 'analogChNum', which is passed to frameTimeFromDiode to prevent issues with identifying the sync analog channel.

As this is a branch of Mark--development, I merge it back to its original branch to prevent future conflicts in the master.